### PR TITLE
Improvements of APIs

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -12,7 +12,12 @@ class URLSerializer(serializers.ModelSerializer):
         model = ShortURL
         fields = [
             "short_url",
+            "short_key",
             "url",
+        ]
+        read_only_fields = [
+            "short_url",
+            "short_key",
         ]
 
     def get_short_url(self, obj):

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -12,11 +12,17 @@ class ShortURLViewSetTestCase(APITestCase):
         self.url = "https://example.com"
         self.obj = ShortURL.objects.create(url=self.url, short_key="abc123")
 
-    def test_create_short_url(self):
+    def test_create_new_short_url(self):
         data = {"url": "https://new-example.com"}
         response = self.client.post(reverse("short-url-list"), data)
         self.assertEqual(response.status_code, 201)
         self.assertTrue(ShortURL.objects.filter(url=data["url"]).exists())
+
+    def test_create_existing_short_url(self):
+        data = {"url": self.url}
+        response = self.client.post(reverse("short-url-list"), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["url"], self.url)
 
     def test_retrieve_short_url(self):
         response = self.client.get(

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,4 @@
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, status, viewsets
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,6 +13,15 @@ class ShortURLViewSet(
 ):
     queryset = ShortURL.objects.all()
     serializer_class = URLSerializer
+
+    def create(self, request, *args, **kwargs):
+        if ShortURL.objects.filter(url=request.data["url"]).exists():
+            obj = ShortURL.objects.get(url=request.data["url"])
+            return Response(
+                {"short_url": get_short_url(obj, self.request), "url": obj.url},
+                status=status.HTTP_200_OK,
+            )
+        return super().create(request, *args, **kwargs)
 
 
 class RedirectView(APIView):


### PR DESCRIPTION
- return `short_key` in `/api/short-url` endpoint responses
- on `POST /api/short-url`, for a given URL, return data if object already exists
- added new `GET /api/short-url/?url=http://example.com"` method to get data based on long URL